### PR TITLE
feature: 리뷰와 맛집 조회에서 사용자에 대한 정보를 포함시키기

### DIFF
--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/TodaysLunchConfig.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/TodaysLunchConfig.java
@@ -15,15 +15,14 @@ public class TodaysLunchConfig {
     private final LocationTagRepository locationTagRepository;
     private final MenuRepository menuRepository;
     private final ReviewRepository reviewRepository;
-
     private final MemberRepository memberRepository;
-
     private final ImageUrlRepository imageUrlRepository;
     private final SaleRepository saleRepository;
     private final AgreementRepository agreementRepository;
     private final RecommendCategoryRepository recommendCategoryRepository;
     private final RestRecmdRelRepository restRecmdRelRepository;
     private final ReviewLikeRepository reviewLikeRepository;
+    private final RestaurantContributorRepository restaurantContributorRepository;
 
     @Autowired
     public TodaysLunchConfig(DataJpaRestaurantRepository restaurantRepository,
@@ -36,7 +35,8 @@ public class TodaysLunchConfig {
                             AgreementRepository agreementRepository,
                             RecommendCategoryRepository recommendCategoryRepository,
                             RestRecmdRelRepository restRecmdRelRepository,
-                            ReviewLikeRepository reviewLikeRepository) {
+                            ReviewLikeRepository reviewLikeRepository,
+                            RestaurantContributorRepository restaurantContributorRepository) {
         this.restaurantRepository = restaurantRepository;
         this.foodCategoryRepository = foodCategoryRepository;
         this.locationCategoryRepository = locationCategoryRepository;
@@ -50,6 +50,7 @@ public class TodaysLunchConfig {
         this.recommendCategoryRepository = recommendCategoryRepository;
         this.restRecmdRelRepository = restRecmdRelRepository;
         this.reviewLikeRepository = reviewLikeRepository;
+        this.restaurantContributorRepository = restaurantContributorRepository;
     }
 
     @Bean
@@ -63,7 +64,7 @@ public class TodaysLunchConfig {
 
     @Bean
     public MenuService menuService() {
-        return new MenuService(menuRepository, imageUrlRepository, restaurantRepository);
+        return new MenuService(menuRepository, imageUrlRepository, restaurantRepository, restaurantContributorRepository);
     }
 
     @Bean

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/TodaysLunchConfig.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/TodaysLunchConfig.java
@@ -59,7 +59,8 @@ public class TodaysLunchConfig {
             foodCategoryRepository, locationTagRepository,
             locationCategoryRepository, imageUrlRepository,
             memberRepository, agreementRepository,
-            recommendCategoryRepository, restRecmdRelRepository);
+            recommendCategoryRepository, restRecmdRelRepository,
+            restaurantContributorRepository);
     }
 
     @Bean

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
@@ -69,7 +69,7 @@ public class MenuController {
     return ResponseEntity.status(HttpStatus.OK).body(menu);
   }
 
-  @PostMapping("menus/{menuId}/image")
+  @PostMapping("menus/{menuId}/images")
   public ResponseEntity<Void> createMenuImage(
       @RequestParam MultipartFile menuImage,
       @PathVariable Long menuId,
@@ -79,13 +79,13 @@ public class MenuController {
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 
-  @GetMapping("menus/{menuId}/image")
+  @GetMapping("menus/{menuId}/images")
   public ResponseEntity<List<MenuImageDto>> menuImageList(@PathVariable Long menuId){
     List<MenuImageDto> menuImages = menuService.menuImageList(menuId);
     return ResponseEntity.status(HttpStatus.OK).body(menuImages);
   }
 
-  @DeleteMapping("menus/{menuId}/image/{imageId}")
+  @DeleteMapping("menus/{menuId}/images/{imageId}")
   public ResponseEntity<Void> deleteMenuImage(
       @PathVariable Long menuId,
       @PathVariable Long imageId

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
@@ -51,16 +51,23 @@ public class MenuController {
   }
 
   @PostMapping("restaurants/{restaurantId}/menus")
-  public ResponseEntity<Void> createMenu(@RequestBody MenuDto menuDto, @PathVariable Long restaurantId){
-    menuService.create(menuDto, restaurantId);
+  public ResponseEntity<Void> createMenu(
+      @RequestBody MenuDto menuDto,
+      @PathVariable Long restaurantId,
+      @AuthenticationPrincipal Member member){
+    menuService.create(menuDto, restaurantId, member);
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 
   @PatchMapping("restaurants/{restaurantId}/menus/{menuId}")
-  public ResponseEntity<Menu> updateMenu(@RequestParam(required = false) String name, @RequestParam(required = false) Long price,
-      @PathVariable Long restaurantId, @PathVariable Long menuId) {
-    Menu menu = menuService.update(name, price, restaurantId, menuId);
-    return ResponseEntity.status(HttpStatus.OK).body(menu);
+  public ResponseEntity<Void> updateMenu(
+      @RequestParam(required = false) String name,
+      @RequestParam(required = false) Long price,
+      @PathVariable Long restaurantId,
+      @PathVariable Long menuId,
+      @AuthenticationPrincipal Member member) {
+    menuService.update(name, price, restaurantId, menuId, member);
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 
   @DeleteMapping("restaurants/{restaurantId}/menus/{menuId}")

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
@@ -33,6 +33,8 @@ public class Member implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(nullable = false)
+    private String email;
 
     @Column(nullable = false)
     private String nickname;
@@ -49,7 +51,7 @@ public class Member implements UserDetails {
     private FoodCategory foodCategory;
     @OneToOne
     @JoinColumn
-    private ImageUrl imageUrl;
+    private ImageUrl icon;
 
 
     @ElementCollection(fetch = FetchType.EAGER) //roles 컬렉션

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
@@ -73,7 +73,7 @@ public class Member implements UserDetails {
 
     @Override
     public String getUsername() {
-        return nickname;
+        return email;
     }
 
     public String getPassword() {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
@@ -56,14 +56,14 @@ public class Restaurant {
   private String bestReview;
   @OneToOne
   @JoinColumn
-  private Member member;
+  private Member registrant;
 
   // 맛집 심사를 위한 등록에서 쓰임
   @Builder
   public Restaurant(String restaurantName, FoodCategory foodCategory,
       LocationCategory locationCategory, LocationTag locationTag,
       String address, String introduction, Double longitude, Double latitude,
-      Member member) {
+      Member registrant) {
     this.restaurantName = restaurantName;
     this.foodCategory = foodCategory;
     this.locationCategory = locationCategory;
@@ -75,7 +75,7 @@ public class Restaurant {
     this.endDate = LocalDate.now().plusDays(7);
     this.longitude = longitude;
     this.latitude = latitude;
-    this.member = member;
+    this.registrant = registrant;
     this.agreementCount = new AtomicLong(0);
   }
   public void setId(Long id) {
@@ -90,7 +90,7 @@ public class Restaurant {
   public void setReviewCount(Long reviewCount) {
     this.reviewCount = reviewCount;
   }
-  public void setMember(Member member) { this.member = member; }
+  public void setRegistrant(Member member) { this.registrant = member; }
   public void setLowestPrice(Long lowestPrice) { this.lowestPrice = lowestPrice; }
   public void setAgreementCount(AtomicLong agreementCount) { this.agreementCount = agreementCount; }
   public void setJudgement(Boolean judgement) { this.judgement = judgement; }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/relation/RestaurantContributor.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/relation/RestaurantContributor.java
@@ -1,0 +1,33 @@
+package LikeLion.TodaysLunch.domain.relation;
+
+import LikeLion.TodaysLunch.domain.Member;
+import LikeLion.TodaysLunch.domain.Restaurant;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RestaurantContributor {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  @JoinColumn
+  private Restaurant restaurant;
+  @ManyToOne
+  @JoinColumn
+  private Member member;
+  @Builder
+  public RestaurantContributor(Restaurant restaurant, Member member){
+    this.restaurant = restaurant;
+    this.member = member;
+  }
+}

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/ContributorDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/ContributorDto.java
@@ -1,0 +1,28 @@
+package LikeLion.TodaysLunch.dto;
+
+import LikeLion.TodaysLunch.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContributorDto {
+  private Long id;
+  private String nickname;
+  private String icon;
+  public static ContributorDto fromEntity(Member member){
+    String image = null;
+    if(member.getIcon() != null){
+      image = member.getIcon().getImageUrl();
+    }
+    return ContributorDto.builder()
+        .id(member.getId())
+        .nickname(member.getNickname())
+        .icon(image)
+        .build();
+  }
+}

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/JudgeRestaurantDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/JudgeRestaurantDto.java
@@ -14,7 +14,7 @@ public class JudgeRestaurantDto {
   private Long id;
   private String restaurantName;
   private String introduction;
-  private String nickname;
+  private String registrant;
   private String imageUrl;
   private Double latitude;
   private Double longitude;
@@ -28,7 +28,7 @@ public class JudgeRestaurantDto {
         .id(restaurant.getId())
         .restaurantName(restaurant.getRestaurantName())
         .introduction(restaurant.getIntroduction())
-        .nickname(restaurant.getMember().getNickname())
+        .registrant(restaurant.getRegistrant().getNickname())
         .imageUrl(image)
         .latitude(restaurant.getLatitude())
         .longitude(restaurant.getLongitude())

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/JudgeRestaurantListDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/JudgeRestaurantListDto.java
@@ -14,7 +14,7 @@ public class JudgeRestaurantListDto {
   private Long id;
   private String restaurantName;
   private String introduction;
-  private String nickname;
+  private String registrant;
   private String imageUrl;
   private String foodCategory;
   private String locationCategory;
@@ -29,7 +29,7 @@ public class JudgeRestaurantListDto {
         .id(restaurant.getId())
         .restaurantName(restaurant.getRestaurantName())
         .introduction(restaurant.getIntroduction())
-        .nickname(restaurant.getMember().getNickname())
+        .registrant(restaurant.getRegistrant().getNickname())
         .imageUrl(image)
         .foodCategory(restaurant.getFoodCategory().getName())
         .locationCategory(restaurant.getLocationCategory().getName())

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberDto.java
@@ -5,14 +5,19 @@ import LikeLion.TodaysLunch.domain.ImageUrl;
 import LikeLion.TodaysLunch.domain.LocationCategory;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class MemberDto {
     @NotNull
-    private String nickname;
+    private String email;
 
     @NotNull
     private String password;
+
+    @NotNull
+    private String nickname;
 
     private LocationCategory locationCategory;
 
@@ -20,23 +25,4 @@ public class MemberDto {
 
     private ImageUrl imageUrl;
 
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public void setLocationCategory(LocationCategory locationCategory) {
-        this.locationCategory = locationCategory;
-    }
-
-    public void setFoodCategory(FoodCategory foodCategory) {
-        this.foodCategory = foodCategory;
-    }
-
-    public void setImageUrl(ImageUrl imageUrl) {
-        this.imageUrl = imageUrl;
-    }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberDtoMapper.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberDtoMapper.java
@@ -12,7 +12,7 @@ public class MemberDtoMapper {
         dto.setPassword(member.getPassword());
         dto.setLocationCategory(member.getLocationCategory());
         dto.setFoodCategory(member.getFoodCategory());
-        dto.setImageUrl(member.getImageUrl());
+        dto.setImageUrl(member.getIcon());
         return dto;
     }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberDtoMapper.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberDtoMapper.java
@@ -8,6 +8,7 @@ public class MemberDtoMapper {
 
     public static MemberDto toDto(Member member) {
         MemberDto dto = new MemberDto();
+        dto.setEmail(member.getEmail());
         dto.setNickname(member.getNickname());
         dto.setPassword(member.getPassword());
         dto.setLocationCategory(member.getLocationCategory());

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberJoinDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberJoinDto.java
@@ -1,16 +1,38 @@
 package LikeLion.TodaysLunch.dto;
 
+import LikeLion.TodaysLunch.domain.FoodCategory;
+import LikeLion.TodaysLunch.domain.LocationCategory;
+import LikeLion.TodaysLunch.domain.Member;
+import java.util.Collections;
 import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class MemberJoinDto {
   @NotBlank(message = "닉네임은 Null과 공백일 수 없습니다!")
   private String nickname;
+  @NotBlank(message = "닉네임은 Null과 공백일 수 없습니다!")
+  private String email;
   @NotBlank(message = "비밀번호는 Null과 공백일 수 없습니다!")
   private String password;
   @NotBlank(message = "음식 카테고리는 Null과 공백일 수 없습니다!")
   private String foodCategory;
   @NotBlank(message = "위치 카테고리는 Null과 공백일 수 없습니다!")
   private String locationCategory;
+  public Member toEntity(FoodCategory foodCategory, LocationCategory locationCategory, String encodedPassword){
+    return Member.builder()
+        .nickname(nickname)
+        .email(email)
+        .password(encodedPassword)
+        .foodCategory(foodCategory)
+        .locationCategory(locationCategory)
+        .roles(Collections.singletonList("ROLE_USER"))
+        .build();
+  }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberLoginDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MemberLoginDto.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 public class MemberLoginDto {
-  @NotBlank(message = "로그인을 위해 닉네임을 입력해주세요")
-  private String nickname;
+  @NotBlank(message = "로그인을 위해 이메일을 입력해주세요")
+  private String email;
   @NotBlank(message = "로그인을 위해 비밀번호를 입력해주세요")
   private String password;
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MenuImageDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/MenuImageDto.java
@@ -11,10 +11,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 public class MenuImageDto {
+  private Long id;
   private String imageUrl;
   private String nickname;
   public static MenuImageDto fromEntity(ImageUrl image){
     return MenuImageDto.builder()
+        .id(image.getId())
         .imageUrl(image.getImageUrl())
         .nickname(image.getMember().getNickname())
         .build();

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/RestaurantDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/RestaurantDto.java
@@ -2,6 +2,7 @@ package LikeLion.TodaysLunch.dto;
 
 import LikeLion.TodaysLunch.domain.FoodCategory;
 import LikeLion.TodaysLunch.domain.Restaurant;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -27,7 +28,8 @@ public class RestaurantDto {
   private Double rating;
   private Long reviewCount;
   private String nickname;
-  public static RestaurantDto fromEntity(Restaurant restaurant){
+  private List<ContributorDto> contributors;
+  public static RestaurantDto fromEntity(Restaurant restaurant, List<ContributorDto> contributors){
     String image = null;
     if (restaurant.getImageUrl() != null){
       image = restaurant.getImageUrl().getImageUrl();
@@ -53,6 +55,8 @@ public class RestaurantDto {
         .address(restaurant.getAddress())
         .rating(restaurant.getRating())
         .reviewCount(restaurant.getReviewCount())
-        .nickname(nickname).build();
+        .nickname(nickname)
+        .contributors(contributors)
+        .build();
   }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/RestaurantDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/RestaurantDto.java
@@ -27,16 +27,16 @@ public class RestaurantDto {
   private String address;
   private Double rating;
   private Long reviewCount;
-  private String nickname;
+  private ContributorDto registrant;
   private List<ContributorDto> contributors;
   public static RestaurantDto fromEntity(Restaurant restaurant, List<ContributorDto> contributors){
     String image = null;
     if (restaurant.getImageUrl() != null){
       image = restaurant.getImageUrl().getImageUrl();
     }
-    String nickname = null;
-    if(restaurant.getMember() != null){
-      nickname = restaurant.getMember().getNickname();
+    ContributorDto registrant = null;
+    if(restaurant.getRegistrant() != null){
+      registrant = ContributorDto.fromEntity(restaurant.getRegistrant());
     }
     return RestaurantDto.builder()
         .id(restaurant.getId())
@@ -55,7 +55,7 @@ public class RestaurantDto {
         .address(restaurant.getAddress())
         .rating(restaurant.getRating())
         .reviewCount(restaurant.getReviewCount())
-        .nickname(nickname)
+        .registrant(registrant)
         .contributors(contributors)
         .build();
   }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/ReviewDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/ReviewDto.java
@@ -14,17 +14,13 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ReviewDto {
   private Long id;
+  private ReviewProfileDto member;
   @NotBlank(message = "리뷰 내용은 Null과 공백일 수 없습니다!")
   private String reviewContent;
   @NotBlank(message = "별점은 Null과 공백일 수 없습니다!")
   private Integer rating;
   private LocalDate createdDate;
   private Long likeCount;
-  @Builder
-  public ReviewDto(String reviewContent, Integer rating){
-    this.rating = rating;
-    this.reviewContent = reviewContent;
-  }
 
   public Review toEntity(){
     return Review.builder().rating(rating).reviewContent(reviewContent).build();
@@ -37,6 +33,7 @@ public class ReviewDto {
         .reviewContent(review.getReviewContent())
         .createdDate(review.getCreatedDate())
         .likeCount(review.getLikeCount().get())
+        .member(ReviewProfileDto.fromEntity(review.getMember()))
         .build();
   }
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/ReviewProfileDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/dto/ReviewProfileDto.java
@@ -1,0 +1,30 @@
+package LikeLion.TodaysLunch.dto;
+
+import LikeLion.TodaysLunch.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewProfileDto {
+  private Long id;
+  private String email;
+  private String nickname;
+  private String icon;
+  public static ReviewProfileDto fromEntity(Member member){
+    String image = null;
+    if(member.getIcon() != null){
+      image = member.getIcon().getImageUrl();
+    }
+    return ReviewProfileDto.builder()
+        .id(member.getId())
+        .email(member.getEmail())
+        .nickname(member.getNickname())
+        .icon(image)
+        .build();
+  }
+}

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/MemberRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/MemberRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/RestaurantContributorRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/RestaurantContributorRepository.java
@@ -1,8 +1,11 @@
 package LikeLion.TodaysLunch.repository;
 
+import LikeLion.TodaysLunch.domain.Member;
+import LikeLion.TodaysLunch.domain.Restaurant;
 import LikeLion.TodaysLunch.domain.relation.RestaurantContributor;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantContributorRepository extends JpaRepository<RestaurantContributor, Long> {
-
+    Optional<RestaurantContributor> findByRestaurantAndMember(Restaurant restaurant, Member member);
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/RestaurantContributorRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/RestaurantContributorRepository.java
@@ -1,0 +1,8 @@
+package LikeLion.TodaysLunch.repository;
+
+import LikeLion.TodaysLunch.domain.relation.RestaurantContributor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantContributorRepository extends JpaRepository<RestaurantContributor, Long> {
+
+}

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/RestaurantContributorRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/RestaurantContributorRepository.java
@@ -3,9 +3,11 @@ package LikeLion.TodaysLunch.repository;
 import LikeLion.TodaysLunch.domain.Member;
 import LikeLion.TodaysLunch.domain.Restaurant;
 import LikeLion.TodaysLunch.domain.relation.RestaurantContributor;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantContributorRepository extends JpaRepository<RestaurantContributor, Long> {
     Optional<RestaurantContributor> findByRestaurantAndMember(Restaurant restaurant, Member member);
+    List<RestaurantContributor> findAllByRestaurant(Restaurant restaurant);
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/RestaurantService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/RestaurantService.java
@@ -109,7 +109,7 @@ RestaurantService {
         .introduction(createDto.getIntroduction())
         .longitude(createDto.getLongitude())
         .latitude(createDto.getLatitude())
-        .member(member)
+        .registrant(member)
         .build();
 
     if(!restaurantImage.isEmpty()) {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/login/CustomUserDetailService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/login/CustomUserDetailService.java
@@ -13,8 +13,8 @@ public class CustomUserDetailService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
-        return memberRepository.findByNickname(nickname)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다"));
     }
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/login/MemberService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/login/MemberService.java
@@ -50,24 +50,24 @@ public class MemberService {
     }
 
     private void validateDuplication(MemberJoinDto memberDto) {
-        if (memberRepository.findByNickname(memberDto.getNickname()).isPresent()) {
-            throw new DuplicationException("아이디");
+        if (memberRepository.findByEmail(memberDto.getEmail()).isPresent()) {
+            throw new DuplicationException("이메일");
         }
     }
 
     @Transactional
     public TokenDto login(MemberLoginDto memberDto) {
-        Member member = memberRepository.findByNickname(memberDto.getNickname())
-                .orElseThrow(() -> new NotFoundException("아이디"));
+        Member member = memberRepository.findByEmail(memberDto.getEmail())
+                .orElseThrow(() -> new NotFoundException("이메일"));
 
         if (!passwordEncoder.matches(memberDto.getPassword(), member.getPassword())) {
             throw new UnauthorizedException("회원정보의 비밀번호와 일치하지 않습니다.");
         }
 
-        TokenDto tokenDto = jwtTokenProvider.createToken(member.getNickname(), member.getRoles());
+        TokenDto tokenDto = jwtTokenProvider.createToken(member.getEmail(), member.getRoles());
         long expiration = JwtTokenProvider.getExpirationTime(tokenDto.getToken()).getTime();
         redisTemplate.opsForValue()
-                .set(member.getNickname(), tokenDto.getToken(), expiration, TimeUnit.MILLISECONDS);
+                .set(member.getEmail(), tokenDto.getToken(), expiration, TimeUnit.MILLISECONDS);
 
         return tokenDto;
     }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/login/MemberService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/login/MemberService.java
@@ -44,13 +44,7 @@ public class MemberService {
         LocationCategory locationCategory = locationCategoryRepository.findByName(memberDto.getLocationCategory())
             .orElseThrow(() -> new NotFoundException("위치 카테고리"));
 
-        Member member = Member.builder()
-                .nickname(memberDto.getNickname())
-                .password(passwordEncoder.encode(memberDto.getPassword()))
-            .foodCategory(foodCategory)
-            .locationCategory(locationCategory)
-                .roles(Collections.singletonList("ROLE_USER"))
-                .build();
+        Member member = memberDto.toEntity(foodCategory, locationCategory, passwordEncoder.encode(memberDto.getPassword()));
 
         return memberRepository.save(member).getId();
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 변경 사항
리뷰와 맛집을 조회할 때 등록자에 대한 정보(id, 닉네임, 아이콘)를 포함하여 반환하도록 변경하였다. 또한 맛집의 경우, 심사를 통해 맛집을 등록한 등록자 뿐 아니라 메뉴를 등록하고 수정한 '기여자'들에 대한 데이터도 저장하고 반환하도록 수정되었다. 따라서 사용자(Member Entity)와 맛집(Restaurant Entity) 간의 다대다관계(Many To Many)에대한 Entity를 생성하고 '기여자'들을 관리하도록 하였다. 

## Issue number and link
#22 

