### PR TITLE
feature: 도메인 상세 설정하고 jpa 영속성 컨텍스트 작동원리에 맞게 리팩토링하기

### DIFF
--- a/TodaysLunch/.gitignore
+++ b/TodaysLunch/.gitignore
@@ -33,5 +33,6 @@ out/
 /nbdist/
 /.nb-gradle/
 
-### VS Code ###
-.vscode/
+
+### secret key ###
+src/main/resources/application-secret.properties

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/FoodCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/FoodCategory.java
@@ -18,7 +18,7 @@ public class FoodCategory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length=30)
   private String name;
 
   public FoodCategory update(String name) {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationCategory.java
@@ -18,7 +18,7 @@ public class LocationCategory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length=30)
   private String name;
 
   @Column(nullable = false)

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationRelation.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationRelation.java
@@ -1,6 +1,7 @@
 package LikeLion.TodaysLunch.category.domain;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -14,12 +15,12 @@ public class LocationRelation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private LocationCategory locationCategory;
 
-    @ManyToOne
-    @JoinColumn
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private LocationTag locationTag;
 
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationTag.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationTag.java
@@ -18,7 +18,7 @@ public class LocationTag {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length=30)
   private String name;
 
   @Column(nullable = false)

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/RecommendCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/RecommendCategory.java
@@ -19,10 +19,10 @@ public class RecommendCategory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length=30)
   private String name;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length=10)
   private String color;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/service/CategoryService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/service/CategoryService.java
@@ -63,36 +63,43 @@ public class CategoryService {
 
   public void recommendCategoryEdit(Long restaurantId, RecommendCategoryDto.Edit editDto){
     Map<RecommendCategory, RestaurantRecommendCategoryRelation> pair = new HashMap<>();
+
     Restaurant restaurant = restaurantRepository.findById(restaurantId)
         .orElseThrow(() -> new NotFoundException("맛집"));
+
     List<RestaurantRecommendCategoryRelation> existingRelations = restRecmdRelRepository.findAllByRestaurant(restaurant);
+
     List<RecommendCategory> existingCategories = new ArrayList<>();
     for(RestaurantRecommendCategoryRelation relation : existingRelations){
       RecommendCategory category = relation.getRecommendCategory();
       pair.put(category, relation);
       existingCategories.add(category);
     }
+
     List<RecommendCategory> newCategories = new ArrayList<>();
     for(Long id: editDto.getRecommendCategoryIds()){
       newCategories.add(recommendCategoryRepository.findById(id)
           .orElseThrow(() -> new NotFoundException("추천 카테고리")));
     }
+
     List<RecommendCategory> objCategories = new ArrayList<>(newCategories);
     objCategories.removeAll(existingCategories); // 새로 추가할 category들
     existingCategories.removeAll(newCategories); // 삭제할 category들
+
     for(RecommendCategory category: existingCategories){
       restRecmdRelRepository.delete(pair.get(category));
       restaurant.deleteRecommendCategoryRelation(pair.get(category));
     }
+
     for(RecommendCategory category: objCategories){
       RestaurantRecommendCategoryRelation relation = new RestaurantRecommendCategoryRelation(restaurant, category);
       restRecmdRelRepository.save(relation);
       restaurant.addRecommendCategoryRelation(relation);
     }
-    if(objCategories.size()>0 || existingCategories.size()>0){
+
+    if(objCategories.size()>0 || existingCategories.size()>0)
       restaurant.setUpdatedDate(LocalDateTime.now());
-      restaurantRepository.save(restaurant);
-    }
+
   }
 
   public void createFoodCategory(String foodCategoryName){
@@ -114,25 +121,25 @@ public class CategoryService {
   public void updateFoodCategory(Long id, String foodCategoryName){
     FoodCategory foodCategory = foodCategoryRepository.findById(id)
         .orElseThrow(() -> new NotFoundException("음식 카테고리"));
-    foodCategoryRepository.save(foodCategory.update(foodCategoryName));
+    foodCategory.update(foodCategoryName);
   }
 
   public void updateLocationCategory(Long id, LocationCategoryDto locationCategoryDto){
     LocationCategory locationCategory = locationCategoryRepository.findById(id)
         .orElseThrow(() -> new NotFoundException("위치 카테고리"));
-    locationCategoryRepository.save(locationCategory.update(locationCategoryDto));
+    locationCategory.update(locationCategoryDto);
   }
 
   public void updateLocationTag(Long id, LocationTagDto locationTagDto){
     LocationTag locationTag = locationTagRepository.findById(id)
         .orElseThrow(() -> new NotFoundException("위치 태그"));
-    locationTagRepository.save(locationTag.update(locationTagDto));
+    locationTag.update(locationTagDto);
   }
 
   public  void updateRecommendCategory(Long id, RecommendCategoryDto.CategoryList categoryDto){
     RecommendCategory recommendCategory = recommendCategoryRepository.findById(id)
         .orElseThrow(() -> new NotFoundException("추천 카테고리"));
-    recommendCategoryRepository.save(recommendCategory.update(categoryDto));
+    recommendCategory.update(categoryDto);
   }
 
   public void deleteFoodCategory(Long id){

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberFoodCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberFoodCategory.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.customized.domain;
 import LikeLion.TodaysLunch.category.domain.FoodCategory;
 import LikeLion.TodaysLunch.member.domain.Member;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -21,12 +22,12 @@ public class MemberFoodCategory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private FoodCategory foodCategory;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberLocationCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberLocationCategory.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.customized.domain;
 import LikeLion.TodaysLunch.category.domain.LocationCategory;
 import LikeLion.TodaysLunch.member.domain.Member;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -21,12 +22,12 @@ public class MemberLocationCategory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private LocationCategory locationCategory;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MyStore.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MyStore.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.customized.domain;
 import LikeLion.TodaysLunch.member.domain.Member;
 import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -20,12 +21,12 @@ public class MyStore {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
     @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    @ManyToOne
     @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Restaurant restaurant;
 
     public MyStore(Member member, Restaurant restaurant){

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/domain/ImageUrl.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/domain/ImageUrl.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.image.domain;
 import LikeLion.TodaysLunch.member.domain.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -23,15 +24,15 @@ public class ImageUrl {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 300)
   private String originalName;
 
   @Column(nullable = false)
   private String imageUrl;
 
   // 이미지 등록자
-  @OneToOne
   @JoinColumn(nullable = false)
+  @OneToOne(fetch = FetchType.LAZY)
   private Member member;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/domain/MenuImage.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/domain/MenuImage.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.image.domain;
 import LikeLion.TodaysLunch.menu.domain.Menu;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -18,8 +19,8 @@ public class MenuImage {
   @Id
   private Long imagePk;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Menu menu;
 
   @Column(nullable = false)

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/domain/Member.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/domain/Member.java
@@ -33,10 +33,10 @@ public class Member implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
     private String nickname;
 
     @Column(nullable = false)
@@ -45,8 +45,8 @@ public class Member implements UserDetails {
     @Column(nullable = false)
     private Long myStoreCount;
 
-    @OneToOne
     @JoinColumn
+    @OneToOne(fetch = FetchType.LAZY)
     private ImageUrl icon;
 
     @Column(nullable = false)

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/dto/JoinDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/dto/JoinDto.java
@@ -3,8 +3,10 @@ package LikeLion.TodaysLunch.member.dto;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public abstract class JoinDto {
 
   @NotBlank(message = "닉네임은 Null, 공백일 수 없습니다.")

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/dto/MemberJoinDto.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/dto/MemberJoinDto.java
@@ -5,8 +5,10 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class MemberJoinDto extends JoinDto{
 
   private List<String> foodCategoryList;

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/service/MemberService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/service/MemberService.java
@@ -245,7 +245,6 @@ public class MemberService {
             ImageUrl del = imageUrlRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("유저의 아이콘"));
             member.updateIcon(null);
-            memberRepository.save(member);
             imageUrlRepository.delete(del);
         }
 
@@ -264,8 +263,8 @@ public class MemberService {
             imageUrlRepository.save(userImage);
             // 멤버에 저장
             member.updateIcon(userImage);
-            memberRepository.save(member);
         }
+        memberRepository.save(member);
     }
 
     public Member checkExistingEmail(String email){

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/domain/Menu.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/domain/Menu.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.menu.domain;
 import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -21,7 +22,7 @@ public class Menu {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 25)
   private String name;
 
   @Column(nullable = false)
@@ -29,13 +30,14 @@ public class Menu {
 
   private Long salePrice;
 
+  @Column(length = 200)
   private String saleExplain;
 
   @Column(nullable = false)
   private Long imageCount;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Restaurant restaurant;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/service/MenuService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/service/MenuService.java
@@ -90,8 +90,7 @@ public class MenuService {
 
     // 최저 메뉴 가격 설정
     Long originalLowestPrice = restaurant.getLowestPrice();
-
-    if(originalLowestPrice == menu.getPrice() || originalLowestPrice == menu.getSalePrice())
+    if (originalLowestPrice.equals(menu.getPrice()) || originalLowestPrice.equals(menu.getSalePrice()))
       originalLowestPrice = null;
     if (originalLowestPrice == null || originalLowestPrice > price)
       restaurant.setLowestPrice(price);

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/service/MenuService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/service/MenuService.java
@@ -129,13 +129,13 @@ public class MenuService {
         .orElseThrow(() -> new NotFoundException("맛집"));
 
     Long originalPrice = menu.getPrice() > menu.getSalePrice() ? menu.getSalePrice() : menu.getPrice();
-    if(originalPrice == restaurant.getLowestPrice()){
+    if(originalPrice.equals(restaurant.getLowestPrice())){
       Long price = null;
       Long lowestPrice = 10000000L;
 
       List<Menu> menuList = menuRepository.findAllByRestaurant(restaurant);
       for(Menu m: menuList){
-        if(m.getId() != menu.getId()) {
+        if(!m.getId().equals(menu.getId())) {
           if (m.getSalePrice() != null)
             price = m.getPrice() > m.getSalePrice() ? m.getSalePrice() : m.getPrice();
           else
@@ -265,7 +265,7 @@ public class MenuService {
 
     List<MenuImage> menuImages = menuImageRepository.findAllByMenu(menuImage.getMenu());
     for(MenuImage m: menuImages){
-      if(m.getImagePk() != imageId && m.getIsBest()){
+      if(!(m.getImagePk().equals(imageId)) && m.getIsBest()){
         m.setBest(false);
         menuImageRepository.save(m);
       }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/service/MenuService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/service/MenuService.java
@@ -70,7 +70,6 @@ public class MenuService {
     createRestaurantContributor(restaurant, member);
 
     restaurant.setUpdatedDate(LocalDateTime.now());
-    restaurantRepository.save(restaurant);
 
     Menu menu = menuDto.toEntity();
     menu.setRestaurant(restaurant);
@@ -98,10 +97,8 @@ public class MenuService {
     createRestaurantContributor(restaurant, member);
 
     restaurant.setUpdatedDate(LocalDateTime.now());
-    restaurantRepository.save(restaurant);
 
     menu = menuDto.updateMenu(menu);
-    menuRepository.save(menu);
   }
 
   public Menu delete(Long restaurantId, Long menuId){
@@ -150,8 +147,6 @@ public class MenuService {
         restaurant.setLowestPrice(lowestPrice);
       else
         restaurant.setLowestPrice(null);
-
-      restaurantRepository.save(restaurant);
     }
 
     menuRepository.delete(menu);
@@ -168,7 +163,6 @@ public class MenuService {
       menu.setImageCount(++count);
       menu.getRestaurant().setUpdatedDate(LocalDateTime.now());
       restaurantRepository.save(menu.getRestaurant());
-      menuRepository.save(menu);
 
       // s3에 이미지 저장
       String savedUrl = s3UploadService.upload(image, "menu");
@@ -224,7 +218,6 @@ public class MenuService {
 
     Long count = menu.getImageCount();
     menu.setImageCount(--count);
-    menuRepository.save(menu);
 
     s3UploadService.delete(imageUrl.getImageUrl());
     imageUrlRepository.delete(imageUrl);
@@ -261,14 +254,11 @@ public class MenuService {
         .orElseThrow(() -> new NotFoundException("메뉴와 이미지의 관계"));
 
     menuImage.setBest(true);
-    menuImageRepository.save(menuImage);
 
     List<MenuImage> menuImages = menuImageRepository.findAllByMenu(menuImage.getMenu());
     for(MenuImage m: menuImages){
-      if(!(m.getImagePk().equals(imageId)) && m.getIsBest()){
+      if(!(m.getImagePk().equals(imageId)) && m.getIsBest())
         m.setBest(false);
-        menuImageRepository.save(m);
-      }
     }
   }
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Agreement.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Agreement.java
@@ -2,6 +2,7 @@ package LikeLion.TodaysLunch.restaurant.domain;
 
 import LikeLion.TodaysLunch.member.domain.Member;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -19,12 +20,12 @@ public class Agreement {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Restaurant restaurant;
 
   public Agreement(Member member, Restaurant restaurant) {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Restaurant.java
@@ -29,26 +29,26 @@ public class Restaurant {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 20)
   private String restaurantName;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private FoodCategory foodCategory;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private LocationCategory locationCategory;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private LocationTag locationTag;
 
-  @OneToMany(mappedBy="restaurant", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy="restaurant", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private Set<RestaurantRecommendCategoryRelation> recommendCategoryRelations = new HashSet<>();
 
-  @OneToOne
   @JoinColumn
+  @OneToOne(fetch = FetchType.LAZY)
   private ImageUrl imageUrl;
 
   @Column(nullable = false)
@@ -57,9 +57,10 @@ public class Restaurant {
   @Column(nullable = false)
   private Double longitude;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 150)
   private String address;
 
+  @Column(length = 300)
   private String introduction;
 
   private Double rating;
@@ -86,8 +87,8 @@ public class Restaurant {
   @Column(nullable = false)
   private LocalDateTime updatedDate;
 
-  @OneToOne
-  @JoinColumn
+  @JoinColumn(nullable = false)
+  @OneToOne(fetch = FetchType.LAZY)
   private Member registrant;
 
   // 맛집 심사를 위한 등록에서 쓰임

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantContributor.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantContributor.java
@@ -2,6 +2,7 @@ package LikeLion.TodaysLunch.restaurant.domain;
 
 import LikeLion.TodaysLunch.member.domain.Member;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -20,12 +21,12 @@ public class RestaurantContributor {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Restaurant restaurant;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantRecommendCategoryRelation.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantRecommendCategoryRelation.java
@@ -2,6 +2,7 @@ package LikeLion.TodaysLunch.restaurant.domain;
 
 import LikeLion.TodaysLunch.category.domain.RecommendCategory;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -20,12 +21,12 @@ public class RestaurantRecommendCategoryRelation {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Restaurant restaurant;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private RecommendCategory recommendCategory;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/service/RestaurantService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/service/RestaurantService.java
@@ -240,13 +240,10 @@ public class RestaurantService {
 
       if (agreementCount > 4L)
         restaurant.setJudgement(false);
-
-      restaurantRepository.save(restaurant);
     } else {
       Agreement agreement = agreementRepository.findByMemberAndRestaurant(member, restaurant).get();
       agreementCount -= 1;
       restaurant.setAgreementCount(agreementCount);
-      restaurantRepository.save(restaurant);
       agreementRepository.delete(agreement);
     }
   }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/domain/Review.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/domain/Review.java
@@ -6,6 +6,7 @@ import LikeLion.TodaysLunch.review.dto.ReviewDto;
 import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -25,7 +26,7 @@ public class Review extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(length = 200, nullable = false)
+  @Column(length = 300, nullable = false)
   private String reviewContent;
 
   @Column(nullable = false)
@@ -34,12 +35,12 @@ public class Review extends BaseTimeEntity {
   @Column(nullable = false)
   private Long likeCount;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Restaurant restaurant;
 
-  @OneToOne
   @JoinColumn(nullable = false)
+  @OneToOne(fetch = FetchType.LAZY)
   Member member;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/domain/ReviewLike.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/domain/ReviewLike.java
@@ -2,6 +2,7 @@ package LikeLion.TodaysLunch.review.domain;
 
 import LikeLion.TodaysLunch.member.domain.Member;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -19,12 +20,12 @@ public class ReviewLike {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
 
-  @ManyToOne
   @JoinColumn(nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   private Review review;
 
   public ReviewLike(Member member, Review review) {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/service/ReviewService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/service/ReviewService.java
@@ -121,7 +121,7 @@ public class ReviewService {
     List<Review> reviews= reviewRepository.findAllByRestaurant(restaurant);
     Double sum = 0.0;
     for(Review r: reviews){
-      if(r.getId() != reviewId)
+      if(!r.getId().equals(reviewId))
         sum += r.getRating();
     }
     sum += reviewDto.getRating();
@@ -146,7 +146,7 @@ public class ReviewService {
     List<Review> reviews= reviewRepository.findAllByRestaurant(restaurant);
     Double sum = 0.0;
     for(Review r: reviews){
-      if(r.getId() != reviewId)
+      if(!r.getId().equals(reviewId))
         sum += r.getRating();
     }
     restaurant.setRating((double)sum/count);

--- a/TodaysLunch/src/main/resources/application.properties
+++ b/TodaysLunch/src/main/resources/application.properties
@@ -23,6 +23,7 @@ mail.smtp.port=465
 mail.smtp.socketFactory.port=465
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto-=false
+test-constraint=referential_integrity
 
 # secret key
 spring.profiles.include=secret

--- a/TodaysLunch/src/main/resources/application.properties
+++ b/TodaysLunch/src/main/resources/application.properties
@@ -24,6 +24,6 @@ mail.smtp.socketFactory.port=465
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto-=false
 
-# secret key? ?? ????
-spring.profile.include=secret
+# secret key
+spring.profiles.include=secret
 

--- a/TodaysLunch/src/main/resources/application.properties
+++ b/TodaysLunch/src/main/resources/application.properties
@@ -1,10 +1,8 @@
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
-#spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.url=jdbc:h2:tcp://localhost/~/test
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
-spring.datasource.password=1234
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create
@@ -16,5 +14,16 @@ spring.redis.port=6379
 spring.redis.lettuce.min-idle=0
 spring.redis.lettuce.max-idle=100
 spring.redis.lettuce.max-active=100
-#spring.thymeleaf.cache=false
+mail.smtp.auth=true
+mail.smtp.starttls.required=true
+mail.smtp.starttls.enable=true
+mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+mail.smtp.socketFactory.fallback=false
+mail.smtp.port=465
+mail.smtp.socketFactory.port=465
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
+
+# secret key? ?? ????
+spring.profile.include=secret
 

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/category/service/CategoryServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/category/service/CategoryServiceTest.java
@@ -7,6 +7,7 @@ import LikeLion.TodaysLunch.category.domain.FoodCategory;
 import LikeLion.TodaysLunch.category.domain.RecommendCategory;
 import LikeLion.TodaysLunch.category.dto.RecommendCategoryDto;
 import LikeLion.TodaysLunch.exception.NotFoundException;
+import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import LikeLion.TodaysLunch.restaurant.repository.RestRecmdRelRepository;
 import LikeLion.TodaysLunch.skeleton.service.ServiceTest;
 import LikeLion.TodaysLunch.skeleton.service.TestRestaurant;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 
 class CategoryServiceTest extends ServiceTest {
@@ -51,6 +53,7 @@ class CategoryServiceTest extends ServiceTest {
   }
 
   @Test
+  @Transactional
   void 추천카테고리_수정을_맛집속성에_반영하기(){
     // given
     TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, null);
@@ -60,7 +63,9 @@ class CategoryServiceTest extends ServiceTest {
     categoryService.recommendCategoryEdit(맛집.getRestaurant().getId(),수정_요청);
 
     // then
-    assertEquals(2, 맛집.getRestaurant().getRecommendCategoryRelations().size());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals(2, 수정된_맛집.getRecommendCategoryRelations().size());
   }
 
   @Test
@@ -74,7 +79,9 @@ class CategoryServiceTest extends ServiceTest {
     categoryService.recommendCategoryEdit(맛집.getRestaurant().getId(),수정_요청);
 
     // then
-    LocalDateTime 수정시간 = 맛집.getRestaurant().getUpdatedDate();
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    LocalDateTime 수정시간 = 수정된_맛집.getUpdatedDate();
     assertThat(수정시간).isAfter(생성시간);
   }
 

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/category/service/CategoryServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/category/service/CategoryServiceTest.java
@@ -11,6 +11,7 @@ import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import LikeLion.TodaysLunch.restaurant.repository.RestRecmdRelRepository;
 import LikeLion.TodaysLunch.skeleton.service.ServiceTest;
 import LikeLion.TodaysLunch.skeleton.service.TestRestaurant;
+import LikeLion.TodaysLunch.skeleton.service.TestUser;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,8 @@ class CategoryServiceTest extends ServiceTest {
   @Test
   void 추천카테고리_수정() {
     // given
-    TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, null);
+    TestUser 유저 = makeTestUser("qwer@naver.com", "1234", "유저", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
+    TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, 유저.getMember());
     List<RecommendCategory> 이미_존재하는_카테고리들 = restRecmdRelRepository.findAllByRestaurant(맛집.getRestaurant())
         .stream().map(r->r.getRecommendCategory()).collect(Collectors.toList());
 
@@ -56,7 +58,8 @@ class CategoryServiceTest extends ServiceTest {
   @Transactional
   void 추천카테고리_수정을_맛집속성에_반영하기(){
     // given
-    TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, null);
+    TestUser 유저 = makeTestUser("qwer@naver.com", "1234", "유저", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
+    TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, 유저.getMember());
 
     // when
     RecommendCategoryDto.Edit 수정_요청 = RecommendCategoryDto.Edit.builder().recommendCategoryIds(new ArrayList<>(Arrays.asList(추천카테고리_반환하기(추천카테고리이름1), 추천카테고리_반환하기(추천카테고리이름2)))).build();
@@ -71,7 +74,8 @@ class CategoryServiceTest extends ServiceTest {
   @Test
   void 추천카테고리수정을_맛집_수정시간에_반영하기(){
     // given
-    TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, null);
+    TestUser 유저 = makeTestUser("qwer@naver.com", "1234", "유저", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
+    TestRestaurant 맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구", "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, 유저.getMember());
     LocalDateTime 생성시간 = LocalDateTime.now();
 
     // when

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/category/service/CategoryServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/category/service/CategoryServiceTest.java
@@ -77,4 +77,17 @@ class CategoryServiceTest extends ServiceTest {
     LocalDateTime 수정시간 = 맛집.getRestaurant().getUpdatedDate();
     assertThat(수정시간).isAfter(생성시간);
   }
+
+  @Test
+  void 음식카테고리_수정하기(){
+    // given
+    FoodCategory 음식카테고리 = foodCategoryRepository.findByName("한식")
+        .orElseThrow(() -> new NotFoundException("음식 카테고리"));
+
+    // when
+    categoryService.updateFoodCategory(음식카테고리.getId(), "변경된 이름");
+
+    // then
+    assertEquals("변경된 이름", foodCategoryRepository.findByName("변경된 이름").get().getName());
+  }
 }

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/member/service/MemberServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/member/service/MemberServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 class MemberServiceTest extends ServiceTest {
 
@@ -114,6 +115,7 @@ class MemberServiceTest extends ServiceTest {
   }
 
   @Test
+  @Transactional
   void 유저의_위치카테고리_수정하기() {
     // given
     MemberJoinDto 회원가입_요청 = MemberJoinDto.builder()
@@ -139,6 +141,7 @@ class MemberServiceTest extends ServiceTest {
   }
 
   @Test
+  @Transactional
   void 유저의_음식카테고리_수정하기() {
     // given
     MemberJoinDto 회원가입_요청 = MemberJoinDto.builder()

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/menu/service/MenuServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/menu/service/MenuServiceTest.java
@@ -96,8 +96,12 @@ class MenuServiceTest extends ServiceTest {
     menuService.update(수정_요청2, 정식맛집.getRestaurant().getId(), 등록된_메뉴2.getId(), 유저.getMember());
 
     // then
-    assertEquals(null, 등록된_메뉴1.getSaleExplain());
-    assertEquals("8월첫째주만합니다", 등록된_메뉴2.getSaleExplain());
+    Menu 수정된_메뉴1 = menuRepository.findByName("사케동")
+        .orElseThrow(() -> new NotFoundException("메뉴"));
+    Menu 수정된_메뉴2 = menuRepository.findByName("명란크림우동")
+        .orElseThrow(() -> new NotFoundException("메뉴"));
+    assertEquals(null, 수정된_메뉴1.getSaleExplain());
+    assertEquals("8월첫째주만합니다", 수정된_메뉴2.getSaleExplain());
   }
 
   @Test
@@ -197,7 +201,9 @@ class MenuServiceTest extends ServiceTest {
 
     // when
     menuService.create(새로운_메뉴, 정식맛집.getRestaurant().getId(), 유저.getMember());
-    LocalDateTime 수정시간 = 정식맛집.getRestaurant().getUpdatedDate();
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    LocalDateTime 수정시간 = 수정된_맛집.getUpdatedDate();
 
     //then
     assertThat(수정시간).isAfter(비교시간);
@@ -218,7 +224,9 @@ class MenuServiceTest extends ServiceTest {
 
     // when
     메뉴_생성하기("가츠동", 15000L, 10000L, "서강대학생전용입니다", 정식맛집.getRestaurant().getId(), 유저.getMember());
-    LocalDateTime 수정시간 = 정식맛집.getRestaurant().getUpdatedDate();
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    LocalDateTime 수정시간 = 수정된_맛집.getUpdatedDate();
 
     //then
     assertThat(수정시간).isAfter(비교시간);
@@ -239,7 +247,9 @@ class MenuServiceTest extends ServiceTest {
 
     // when
     menuService.createImage(이미지, 등록된_메뉴.getId(), 유저.getMember());
-    LocalDateTime 수정시간 = 정식맛집.getRestaurant().getUpdatedDate();
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    LocalDateTime 수정시간 = 수정된_맛집.getUpdatedDate();
 
     // then
     assertThat(수정시간).isAfter(비교시간);
@@ -327,7 +337,9 @@ class MenuServiceTest extends ServiceTest {
     Menu 등록된_메뉴3 = 메뉴_생성하기("에비동", 6000L, null, null, 정식맛집.getRestaurant().getId(), 유저.getMember());
 
     // then
-    assertEquals(6000L, 정식맛집.getRestaurant().getLowestPrice());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals(6000L, 수정된_맛집.getLowestPrice());
   }
 
   @Test
@@ -342,7 +354,9 @@ class MenuServiceTest extends ServiceTest {
     menuService.delete(정식맛집.getRestaurant().getId(), 등록된_메뉴2.getId());
 
     // then
-    assertEquals(10000L, 정식맛집.getRestaurant().getLowestPrice());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals(10000L, 수정된_맛집.getLowestPrice());
   }
 
   @Test
@@ -357,7 +371,9 @@ class MenuServiceTest extends ServiceTest {
     menuService.update(수정_요청, 정식맛집.getRestaurant().getId(), 등록된_메뉴1.getId(), 유저.getMember());
 
     // then
-    assertEquals(15000L, 정식맛집.getRestaurant().getLowestPrice());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("정든그릇")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals(15000L, 수정된_맛집.getLowestPrice());
   }
 
 

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/restaurant/service/RestaurantServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/restaurant/service/RestaurantServiceTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 class RestaurantServiceTest extends ServiceTest {
 
@@ -36,6 +37,7 @@ class RestaurantServiceTest extends ServiceTest {
   private MenuRepository menuRepository;
 
   @Test
+  @Transactional
   void 맛집_심사_등록하기() throws IOException {
     // given
     JudgeRestaurantCreateDto 등록_요청 = JudgeRestaurantCreateDto
@@ -71,7 +73,9 @@ class RestaurantServiceTest extends ServiceTest {
     restaurantService.addOrCancelAgreement(유저.getMember(), 맛집.getRestaurant().getId());
 
     // then
-    assertEquals(1L, 맛집.getRestaurant().getAgreementCount());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals(1L, 수정된_맛집.getAgreementCount());
   }
 
   @Test
@@ -88,17 +92,18 @@ class RestaurantServiceTest extends ServiceTest {
     Boolean 이전_심사_상태 = 맛집.getRestaurant().getJudgement();
 
     // when
-    Restaurant restaurantForTest = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
-        .orElseThrow(() -> new NotFoundException("맛집"));
-    restaurantService.addOrCancelAgreement(유저1.getMember(), restaurantForTest.getId());
-    restaurantService.addOrCancelAgreement(유저2.getMember(), restaurantForTest.getId());
-    restaurantService.addOrCancelAgreement(유저3.getMember(), restaurantForTest.getId());
-    restaurantService.addOrCancelAgreement(유저4.getMember(), restaurantForTest.getId());
-    restaurantService.addOrCancelAgreement(유저5.getMember(), restaurantForTest.getId());
+    Long 맛집ID = 맛집.getRestaurant().getId();
+    restaurantService.addOrCancelAgreement(유저1.getMember(), 맛집ID);
+    restaurantService.addOrCancelAgreement(유저2.getMember(), 맛집ID);
+    restaurantService.addOrCancelAgreement(유저3.getMember(), 맛집ID);
+    restaurantService.addOrCancelAgreement(유저4.getMember(), 맛집ID);
+    restaurantService.addOrCancelAgreement(유저5.getMember(), 맛집ID);
 
     // then
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
     assertEquals(true, 이전_심사_상태);
-    assertEquals(false, restaurantForTest.getJudgement());
+    assertEquals(false, 수정된_맛집.getJudgement());
   }
 
   @Test

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/restaurant/service/RestaurantServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/restaurant/service/RestaurantServiceTest.java
@@ -145,8 +145,9 @@ class RestaurantServiceTest extends ServiceTest {
   @Test
   void 로그아웃시_찜한여부_false로_포함하기(){
     // given
+    TestUser 유저 = makeTestUser("qwer@naver.com", "1234", "유저", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
     TestRestaurant 정식맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구",
-        "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, null);
+        "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, 유저.getMember());
 
     // when
     HashMap 응답 = restaurantService.restaurantList(null, null, null, null, null, 0, 2, "rating", "descending", null);
@@ -176,7 +177,8 @@ class RestaurantServiceTest extends ServiceTest {
   @Test
   void 로그아웃시_동의여부_false로_포함하기(){
     // given
-    makeTestJudgeRestaurant("한식", "서강대", "정문", "서울시 마포구", "가츠벤또","정말 맛있다", 126.940155, 37.546924, null);
+    TestUser 유저 = makeTestUser("qwer@naver.com", "1234", "유저", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
+    makeTestJudgeRestaurant("한식", "서강대", "정문", "서울시 마포구", "가츠벤또","정말 맛있다", 126.940155, 37.546924, 유저.getMember());
 
     // when
     HashMap 응답 = restaurantService.judgeRestaurantList(null, null, null, null, 0, 3, "rating", "descending", null, null);
@@ -274,7 +276,7 @@ class RestaurantServiceTest extends ServiceTest {
     TestUser 유저1 = makeTestUser("qwer@naver.com", "1234", "유저1", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
     TestUser 유저2 = makeTestUser("qwer1@naver.com", "1234", "유저2", new ArrayList<>(Arrays.asList("한식")), new ArrayList<>(Arrays.asList("서강대")));
     TestRestaurant 정식맛집 = makeTestRestaurant("한식", "서강대", "정문", "서울시 마포구",
-        "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, null);
+        "정든그릇", "정말 맛있는 집!", 37.546924, 126.940155, 유저1.getMember());
 
     // when
     메뉴_생성하기("사케동", 15000L, 정식맛집.getRestaurant().getId(), 유저1.getMember());

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/review/service/ReviewServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/review/service/ReviewServiceTest.java
@@ -3,6 +3,7 @@ package LikeLion.TodaysLunch.review.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import LikeLion.TodaysLunch.exception.NotFoundException;
 import LikeLion.TodaysLunch.member.domain.Member;
 import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import LikeLion.TodaysLunch.review.domain.Review;
@@ -44,7 +45,9 @@ class ReviewServiceTest extends ServiceTest {
     reviewService.addOrCancelLike(맛집ID, 리뷰2.getId(), 유저2.getMember());
 
     //then
-    assertEquals("아주맛잇군2", 맛집.getRestaurant().getBestReview());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals("아주맛잇군2", 수정된_맛집.getBestReview());
   }
 
   @Test
@@ -89,7 +92,9 @@ class ReviewServiceTest extends ServiceTest {
     reviewService.create(맛집ID, 작성한_리뷰2, 유저1.getMember());
 
     //then
-    Long 맛집의_리뷰_수 = 맛집.getRestaurant().getReviewCount();
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Long 맛집의_리뷰_수 = 수정된_맛집.getReviewCount();
     assertEquals(2L, 맛집의_리뷰_수);
   }
 
@@ -108,16 +113,20 @@ class ReviewServiceTest extends ServiceTest {
     // when
     Long 맛집ID = 맛집.getRestaurant().getId();
     reviewService.create(맛집ID, 작성한_리뷰1, 유저1.getMember());
-    Double 평점1 = 맛집.getRestaurant().getRating();
+    Restaurant 수정된_맛집1 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Double 기존평점 = 수정된_맛집1.getRating();
     reviewService.create(맛집ID, 작성한_리뷰2, 유저1.getMember());
     reviewService.create(맛집ID, 작성한_리뷰3, 유저1.getMember());
     reviewService.create(맛집ID, 작성한_리뷰4, 유저1.getMember());
     reviewService.create(맛집ID, 작성한_리뷰5, 유저1.getMember());
-    Double 평점2 = 맛집.getRestaurant().getRating();
+    Restaurant 수정된_맛집2 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Double 수정된평점 = 수정된_맛집2.getRating();
 
     //then
-    assertEquals(1.0, 평점1);
-    assertEquals((1.0+2.0+5.0+3.0+3.0)/5, 평점2);
+    assertEquals(1.0, 기존평점);
+    assertEquals((1.0+2.0+5.0+3.0+3.0)/5, 수정된평점);
   }
 
   @Test
@@ -134,12 +143,16 @@ class ReviewServiceTest extends ServiceTest {
     Review 생성된_리뷰1 = reviewService.create(맛집ID, 작성한_리뷰, 유저1.getMember());
     Review 생성된_리뷰2 = reviewService.create(맛집ID, 작성한_리뷰2, 유저1.getMember());
     Review 생성된_리뷰3 = reviewService.create(맛집ID, 작성한_리뷰3, 유저1.getMember());
-    Double 기존평점 = 맛집.getRestaurant().getRating();
+    Restaurant 수정된_맛집1 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Double 기존평점 = 수정된_맛집1.getRating();
 
     // when
     ReviewDto 수정한_리뷰 = ReviewDto.builder().reviewContent("생각해보니까 별로인듯").rating(1).build();
     reviewService.update(생성된_리뷰3.getId(), 맛집ID, 수정한_리뷰);
-    Double 수정된평점 = 맛집.getRestaurant().getRating();
+    Restaurant 수정된_맛집2 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Double 수정된평점 = 수정된_맛집2.getRating();
     assertEquals((5.0+2.0+5.0)/3, 기존평점);
     assertEquals((5.0+2.0+1.0)/3, 수정된평점);
   }
@@ -158,11 +171,15 @@ class ReviewServiceTest extends ServiceTest {
     Review 생성된_리뷰1 = reviewService.create(맛집ID, 작성한_리뷰, 유저1.getMember());
     Review 생성된_리뷰2 = reviewService.create(맛집ID, 작성한_리뷰2, 유저1.getMember());
     Review 생성된_리뷰3 = reviewService.create(맛집ID, 작성한_리뷰3, 유저1.getMember());
-    Double 기존평점 = 맛집.getRestaurant().getRating();
+    Restaurant 수정된_맛집1 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Double 기존평점 = 수정된_맛집1.getRating();
 
     // when
     reviewService.delete(생성된_리뷰3.getId(), 맛집ID);
-    Double 수정된평점 = 맛집.getRestaurant().getRating();
+    Restaurant 수정된_맛집2 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    Double 수정된평점 = 수정된_맛집2.getRating();
     assertEquals((5.0+2.0+5.0)/3, 기존평점);
     assertEquals((5.0+2.0)/2, 수정된평점);
   }
@@ -267,7 +284,9 @@ class ReviewServiceTest extends ServiceTest {
     reviewService.create(맛집ID, 작성한_리뷰1, 유저1.getMember());
 
     // then
-    assertEquals(1L, 맛집.getRestaurant().getReviewCount());
+    Restaurant 수정된_맛집 = testRestaurantEnviron.restaurantRepository().findByRestaurantName("가츠벤또")
+        .orElseThrow(() -> new NotFoundException("맛집"));
+    assertEquals(1L, 수정된_맛집.getReviewCount());
   }
 
   Review 리뷰_생성하기(Member member, Restaurant restaurant, String reviewContent, Integer rating){

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/DatabaseCleaner.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/DatabaseCleaner.java
@@ -7,10 +7,14 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DatabaseCleaner implements InitializingBean {
+
+  @Value("${test-constraint}")
+  private String constraint;
   private final List<String> tableNames = new ArrayList<>();
 
   @PersistenceContext
@@ -26,10 +30,10 @@ public class DatabaseCleaner implements InitializingBean {
   }
 
   private void truncate() {
-    entityManager.createNativeQuery("SET referential_integrity = 0").executeUpdate();
+    entityManager.createNativeQuery("SET " + constraint + " = 0").executeUpdate();
     for (String tableName : tableNames)
       entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-    entityManager.createNativeQuery("SET referential_integrity = 1").executeUpdate();
+    entityManager.createNativeQuery("SET " + constraint + " = 1").executeUpdate();
   }
 
   @Override

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/DatabaseCleaner.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/DatabaseCleaner.java
@@ -1,0 +1,45 @@
+package LikeLion.TodaysLunch.skeleton.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+  private final List<String> tableNames = new ArrayList<>();
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @PostConstruct
+  public void findDatabaseTableNames() {
+    List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+    for (Object[] tableInfo : tableInfos) {
+      String tableName = (String) tableInfo[0];
+      tableNames.add(tableName);
+    }
+  }
+
+  private void truncate() {
+    entityManager.createNativeQuery("SET referential_integrity = 0").executeUpdate();
+    for (String tableName : tableNames)
+      entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+    entityManager.createNativeQuery("SET referential_integrity = 1").executeUpdate();
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    findDatabaseTableNames();
+  }
+
+  @Transactional
+  public void clear() {
+    entityManager.clear();
+    truncate();
+  }
+}

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/ServiceTest.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/ServiceTest.java
@@ -12,13 +12,11 @@ import LikeLion.TodaysLunch.category.repository.LocationTagRepository;
 import LikeLion.TodaysLunch.category.repository.RecommendCategoryRepository;
 import java.util.ArrayList;
 import java.util.List;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@Transactional
 public abstract class ServiceTest {
 
   protected final String 추천카테고리이름1 = "혼밥하기 좋으니 가게 🍚";
@@ -36,9 +34,12 @@ public abstract class ServiceTest {
   protected TestUserEnviron testUserEnviron;
   @Autowired
   protected TestRestaurantEnviron testRestaurantEnviron;
+  @Autowired
+  private DatabaseCleaner databaseCleaner;
 
   @BeforeEach
   void beforeEach() {
+    databaseCleaner.clear();
     카테고리_등록하기();
   }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 변경 사항
 JPA는 영속 상태인 객체에 대해 자동 변경 감지 기능을 적용시키기 때문에 레포지토리의 save() 메서드의 업데이트 쿼리 없이도 수정사항을 실제 데이터베이스에 반영시킬 수 있다. 따라서 불필요한 save() 메서드를 생략하였다. 

 또한 Entity 연관관계를 맺을 때 JoinColumn 애너테이션을 사용하는데, 이때 null이 가능한 경우는 nullable을 false로 설정하여 inner join으로 쿼리문이 나가도록 하였다. null이 가능하면 JPA에서는 outer join을 실행하기 때문에 nullable 설정으로 최적화할 수 있다.

 테스트 코드를 디버깅하던 중, 테스트 결과와 실제 DB 데이터가 일치하지 않는 것을 알고 JPA의 트랜잭션을 사용하지 않는 스프링 통합 테스트로 테스트 방식을 변경하였다. DataBaseCleaner 클래스를 만들어서 매 테스트를 실행하기 전 DB의 테이블을 모두 삭제하고 영속성 컨텍스트를 초기화하였다. 

## Issue number and link
#72 

