### PR TITLE
feature: 회원 탈퇴와 맛집 삭제 기능 구현하고 엔티티 간 cascade 설정하기

### DIFF
--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationRelation.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/category/domain/LocationRelation.java
@@ -7,6 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 public class LocationRelation {
@@ -17,10 +19,12 @@ public class LocationRelation {
 
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private LocationCategory locationCategory;
 
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private LocationTag locationTag;
 
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberFoodCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberFoodCategory.java
@@ -12,6 +12,8 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -24,10 +26,12 @@ public class MemberFoodCategory {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Member member;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private FoodCategory foodCategory;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberLocationCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MemberLocationCategory.java
@@ -12,6 +12,8 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -24,10 +26,12 @@ public class MemberLocationCategory {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Member member;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private LocationCategory locationCategory;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MyStore.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/customized/domain/MyStore.java
@@ -2,6 +2,7 @@ package LikeLion.TodaysLunch.customized.domain;
 
 import LikeLion.TodaysLunch.member.domain.Member;
 import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -11,6 +12,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -23,10 +26,12 @@ public class MyStore {
 
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Restaurant restaurant;
 
     public MyStore(Member member, Restaurant restaurant){

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/domain/MenuImage.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/domain/MenuImage.java
@@ -10,6 +10,8 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor
@@ -21,6 +23,7 @@ public class MenuImage {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Menu menu;
 
   @Column(nullable = false)

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/repository/ImageUrlRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/image/repository/ImageUrlRepository.java
@@ -1,9 +1,12 @@
 package LikeLion.TodaysLunch.image.repository;
 
 import LikeLion.TodaysLunch.image.domain.ImageUrl;
+import LikeLion.TodaysLunch.member.domain.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageUrlRepository extends JpaRepository<ImageUrl, Long> {
   Optional<ImageUrl> findByImageUrl(String imageUrl);
+  List<ImageUrl> findAllByMember(Member member);
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/controller/MemberController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -126,6 +127,12 @@ public class MemberController {
     @PostMapping("/admin-join")
     public ResponseEntity<Void> adminJoin(@Valid @RequestBody AdminJoinDto memberDto) {
         memberService.adminJoin(memberDto);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @DeleteMapping("/delete-account")
+    public ResponseEntity<Void> deleteAccount(@AuthenticationPrincipal Member member){
+        memberService.deleteAccount(member);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/domain/Member.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/domain/Member.java
@@ -5,10 +5,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -52,7 +55,14 @@ public class Member implements UserDetails {
     @Column(nullable = false)
     private Boolean temporaryPw;
 
-    @ElementCollection(fetch = FetchType.EAGER) //roles 컬렉션
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(joinColumns = {
+        @JoinColumn(name = "member_id"
+            , referencedColumnName = "id"
+            ,foreignKey=@ForeignKey(name="MEMBER_ROLES_FK"
+            , foreignKeyDefinition = "FOREIGN KEY (member_id) references public.member (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE"))
+    }
+    )
     @Builder.Default
     private List<String> roles = new ArrayList<>();
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/service/MemberService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/member/service/MemberService.java
@@ -17,6 +17,7 @@ import LikeLion.TodaysLunch.member.dto.TokenDto;
 import LikeLion.TodaysLunch.exception.DuplicationException;
 import LikeLion.TodaysLunch.exception.NotFoundException;
 import LikeLion.TodaysLunch.exception.UnauthorizedException;
+import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
 import LikeLion.TodaysLunch.restaurant.repository.DataJpaRestaurantRepository;
 import LikeLion.TodaysLunch.category.repository.FoodCategoryRepository;
 import LikeLion.TodaysLunch.image.repository.ImageUrlRepository;
@@ -26,6 +27,7 @@ import LikeLion.TodaysLunch.customized.repository.MemberLocationCategoryReposito
 import LikeLion.TodaysLunch.member.repository.MemberRepository;
 import LikeLion.TodaysLunch.customized.repository.MyStoreRepository;
 import LikeLion.TodaysLunch.restaurant.repository.RestaurantContributorRepository;
+import LikeLion.TodaysLunch.review.domain.Review;
 import LikeLion.TodaysLunch.review.repository.ReviewRepository;
 import LikeLion.TodaysLunch.external.S3UploadService;
 import LikeLion.TodaysLunch.external.JwtTokenProvider;
@@ -296,6 +298,21 @@ public class MemberService {
         Member member = joinDto.toEntity(passwordEncoder.encode(joinDto.getPassword()));
 
         memberRepository.save(member);
+    }
+
+    public void deleteAccount(Member member){
+        List<Restaurant> restaurants = restaurantRepository.findAllByRegistrant(member);
+        for(Restaurant restaurant: restaurants)
+            restaurant.setNullRegistrant();
+
+        List<ImageUrl> images = imageUrlRepository.findAllByMember(member);
+        for(ImageUrl image: images)
+            image.setMember(null);
+
+        if(member.getIcon() != null)
+            imageUrlRepository.delete(member.getIcon());
+
+        memberRepository.delete(member);
     }
 
     private void validateDuplication(JoinDto memberDto) {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/domain/Menu.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/menu/domain/Menu.java
@@ -12,6 +12,8 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Entity
@@ -38,6 +40,7 @@ public class Menu {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Restaurant restaurant;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/controller/RestaurantController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/controller/RestaurantController.java
@@ -133,4 +133,10 @@ public class RestaurantController {
       @RequestParam(defaultValue = PAGE_SIZE) int size){
     return ResponseEntity.status(HttpStatus.OK).body(restaurantService.contributeRestaurantList(member, page, size));
   }
+
+  @DeleteMapping("/{restaurantId}")
+  public ResponseEntity<Void> deleteRestaurant(@PathVariable Long restaurantId){
+    restaurantService.deleteRestaurant(restaurantId);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Agreement.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Agreement.java
@@ -10,6 +10,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -22,10 +24,12 @@ public class Agreement {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Member member;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Restaurant restaurant;
 
   public Agreement(Member member, Restaurant restaurant) {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/Restaurant.java
@@ -13,6 +13,8 @@ import javax.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor
@@ -34,14 +36,17 @@ public class Restaurant {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private FoodCategory foodCategory;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private LocationCategory locationCategory;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private LocationTag locationTag;
 
   @OneToMany(mappedBy="restaurant", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
@@ -87,7 +92,7 @@ public class Restaurant {
   @Column(nullable = false)
   private LocalDateTime updatedDate;
 
-  @JoinColumn(nullable = false)
+  @JoinColumn
   @OneToOne(fetch = FetchType.LAZY)
   private Member registrant;
 
@@ -139,4 +144,5 @@ public class Restaurant {
   }
 
   public void setUpdatedDate(LocalDateTime date) { this.updatedDate = date; }
+  public void setNullRegistrant() { this.registrant = null; }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantContributor.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantContributor.java
@@ -11,6 +11,8 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -23,10 +25,12 @@ public class RestaurantContributor {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Restaurant restaurant;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Member member;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantRecommendCategoryRelation.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/domain/RestaurantRecommendCategoryRelation.java
@@ -11,6 +11,8 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -23,10 +25,12 @@ public class RestaurantRecommendCategoryRelation {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Restaurant restaurant;
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private RecommendCategory recommendCategory;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/repository/DataJpaRestaurantRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/repository/DataJpaRestaurantRepository.java
@@ -17,4 +17,5 @@ public interface DataJpaRestaurantRepository extends JpaRepository <Restaurant, 
   List<Restaurant> findAllByRegistrantAndJudgement(Member registrant, Boolean judgement);
   Page<Restaurant> findAllByRegistrantAndJudgement(Member registrant, Boolean judgement, Pageable pageable);
   Optional<Restaurant> findByRestaurantName(String restaurantName);
+  List<Restaurant> findAllByRegistrant(Member registrant);
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/service/RestaurantService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/restaurant/service/RestaurantService.java
@@ -392,6 +392,16 @@ public class RestaurantService {
     return pageable;
   }
 
+  public void deleteRestaurant(Long restaurantId){
+    Restaurant restaurant = restaurantRepository.findById(restaurantId)
+        .orElseThrow(() -> new NotFoundException("맛집"));
+
+    if(restaurant.getImageUrl() != null)
+      imageUrlRepository.delete(restaurant.getImageUrl());
+
+    restaurantRepository.delete(restaurant);
+  }
+
   private Specification<Restaurant> determineSpecification(String foodCategory, String locationCategory,
       String locationTag, Long recommendCategoryId, String keyword, Boolean judgement, Member member){
     FoodCategory foodCategoryObj;

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/domain/Review.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/review/domain/Review.java
@@ -4,6 +4,7 @@ import LikeLion.TodaysLunch.common.BaseTimeEntity;
 import LikeLion.TodaysLunch.member.domain.Member;
 import LikeLion.TodaysLunch.review.dto.ReviewDto;
 import LikeLion.TodaysLunch.restaurant.domain.Restaurant;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -16,6 +17,8 @@ import javax.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor
@@ -37,10 +40,12 @@ public class Review extends BaseTimeEntity {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Restaurant restaurant;
 
   @JoinColumn(nullable = false)
   @OneToOne(fetch = FetchType.LAZY)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   Member member;
 
   @Builder

--- a/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/TestUser.java
+++ b/TodaysLunch/src/test/java/LikeLion/TodaysLunch/skeleton/service/TestUser.java
@@ -5,6 +5,7 @@ import LikeLion.TodaysLunch.category.domain.LocationCategory;
 import LikeLion.TodaysLunch.member.domain.Member;
 import LikeLion.TodaysLunch.customized.domain.MemberFoodCategory;
 import LikeLion.TodaysLunch.customized.domain.MemberLocationCategory;
+import java.util.Collections;
 import java.util.List;
 
 public class TestUser {
@@ -14,9 +15,14 @@ public class TestUser {
     this.environ = environ;
   }
   public TestUser 유저_등록하기(String email, String password, String nickname) {
-    Member member = Member.builder().email(email).password(environ.passwordEncoder().encode(password)).nickname(nickname).build();
-    member.setMyStoreCount(0L);
-    member.setTemporaryPw(false);
+    Member member = Member.builder()
+        .email(email)
+        .password(environ.passwordEncoder().encode(password))
+        .nickname(nickname)
+        .roles(Collections.singletonList("ROLE_USER"))
+        .myStoreCount(0L)
+        .temporaryPw(false)
+        .build();
     this.member = environ.memberRepository().save(member);
     return this;
   }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 변경 사항
회원 탈퇴, 맛집 삭제 시 Member와 Restaurant과 연관관계가 있는 Enitity들을 삭제하거나 회원과 맛집을 속성으로 갖는 경우 null로 설정해야 한다. 즉, DB에서 on delete cascade를 설정하거나 on delete set null을 구현해야 한다.


## Issue number and link
#76 

