### PR TITLE
Fix: Redis host와 password를 test 서버와 production 서버로 분리하기

### DIFF
--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/external/RedisRepositoryConfig.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/external/RedisRepositoryConfig.java
@@ -22,10 +22,14 @@ public class RedisRepositoryConfig {
     @Value("${spring.redis.port}")
     private String redisPort;
 
+    @Value("${spring.redis.password}")
+    public String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPassword(password);
         redisStandaloneConfiguration.setPort(Integer.parseInt(redisPort));
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
@@ -39,3 +43,4 @@ public class RedisRepositoryConfig {
         return redisTemplate;
     }
 }
+

--- a/TodaysLunch/src/main/resources/application-test.properties
+++ b/TodaysLunch/src/main/resources/application-test.properties
@@ -12,3 +12,7 @@ spring.jpa.hibernate.ddl-auto=update
 # for test
 test-constraint=referential_integrity
 test-db=h2
+
+# redis
+spring.redis.host=127.0.0.1
+spring.redis.password=test1111!

--- a/TodaysLunch/src/main/resources/application.properties
+++ b/TodaysLunch/src/main/resources/application.properties
@@ -15,7 +15,6 @@ mail.smtp.socketFactory.port=465
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto=false
 # redis
-spring.redis.host=127.0.0.1
 spring.redis.port=6379
 spring.redis.lettuce.min-idle=0
 spring.redis.lettuce.max-idle=100


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 변경 사항
배포 후 로그인을 시도하면 redisconnectionfailureexception이 발생한다. 환경변수 설정으로 host와 password를 설정하여 해결한다.

## Issue number and link
#80 

